### PR TITLE
将serverAddress拆分为本地绑定的bindAddress和注册到serverRegistry的publicAddress

### DIFF
--- a/curry-server/src/main/java/com/nov21th/curry/server/RPCServer.java
+++ b/curry-server/src/main/java/com/nov21th/curry/server/RPCServer.java
@@ -36,9 +36,14 @@ public class RPCServer implements ApplicationContextAware {
     private static final Logger logger = LoggerFactory.getLogger(RPCServer.class);
 
     /**
-     * 服务器的地址，格式为ip:port
+     * 服务器本地绑定的地址，格式为ip:port
      */
-    private String serverAddress;
+    private String bindAddress;
+
+    /**
+     * 服务器对外公布的地址，格式为ip:port
+     */
+    private String publicAddress;
 
     /**
      * 注册服务的接口
@@ -51,7 +56,14 @@ public class RPCServer implements ApplicationContextAware {
     private Map<String, Object> serviceMap = new HashMap<>();
 
     public RPCServer(String serverAddress, ServiceRegistry serviceRegistry) {
-        this.serverAddress = serverAddress;
+        this.bindAddress = serverAddress;
+        this.publicAddress = serverAddress;
+        this.serviceRegistry = serviceRegistry;
+    }
+
+    public RPCServer(String bindAddress, String publicAddress, ServiceRegistry serviceRegistry) {
+        this.bindAddress = bindAddress;
+        this.publicAddress = publicAddress;
         this.serviceRegistry = serviceRegistry;
     }
 
@@ -107,7 +119,7 @@ public class RPCServer implements ApplicationContextAware {
                     .option(ChannelOption.SO_BACKLOG, 1024)
                     .childOption(ChannelOption.SO_KEEPALIVE, true);
 
-            String[] address = serverAddress.split(":");
+            String[] address = bindAddress.split(":");
             String host = address[0];
             int port = Integer.parseInt(address[1]);
 
@@ -130,7 +142,7 @@ public class RPCServer implements ApplicationContextAware {
         if (serviceRegistry != null) {
             for (String serviceFullname : serviceMap.keySet()) {
                 logger.debug("向注册中心注册服务：{}", serviceFullname);
-                serviceRegistry.registerService(serviceFullname, serverAddress);
+                serviceRegistry.registerService(serviceFullname, publicAddress);
             }
         } else {
             throw new RuntimeException("服务中心不可用");


### PR DESCRIPTION
在一些情况下（如服务提供者位于防火墙后），服务调用者想要调用服务提供者需要进行NAT穿透，这时服务提供者需要在本地绑定一个内网地址，但是需要向serviceRegistry注册一个公网地址（例如防火墙的地址），因此我认为可以将原来的serverAddress参数拆分为两个参数bindAddress和publicAddress